### PR TITLE
Increase retrieve flexibility

### DIFF
--- a/src/Quadtree.ts
+++ b/src/Quadtree.ts
@@ -147,7 +147,7 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @param obj - object to be checked
      * @returns Array containing indexes of intersecting subnodes (0-3 = top-right, top-left, bottom-left, bottom-right).
      */
-    getIndex(obj:ObjectsType): number[] {
+    getIndex(obj:Rectangle|Circle|Line|Indexable): number[] {
         return obj.qtIndex(this.bounds);
     }
 
@@ -255,7 +255,7 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @param obj - geometry to be checked
      * @returns Array containing all detected objects.
      */
-    retrieve(obj:ObjectsType): ObjectsType[] {
+    retrieve(obj:Rectangle|Circle|Line|Indexable): ObjectsType[] {
         
         const indexes = this.getIndex(obj);
         let returnObjects = this.objects;

--- a/types/Quadtree.d.ts
+++ b/types/Quadtree.d.ts
@@ -117,7 +117,7 @@ export declare class Quadtree<ObjectsType extends Rectangle | Circle | Line | In
      * @param obj - object to be checked
      * @returns Array containing indexes of intersecting subnodes (0-3 = top-right, top-left, bottom-left, bottom-right).
      */
-    getIndex(obj: ObjectsType): number[];
+    getIndex(obj: Rectangle|Circle|Line|Indexable): number[];
     /**
      * Split the node into 4 subnodes.
      * @internal
@@ -159,7 +159,7 @@ export declare class Quadtree<ObjectsType extends Rectangle | Circle | Line | In
      * @param obj - geometry to be checked
      * @returns Array containing all detected objects.
      */
-    retrieve(obj: ObjectsType): ObjectsType[];
+    retrieve(obj: Rectangle|Circle|Line|Indexable): ObjectsType[];
     /**
      * Clear the Quadtree.
      *


### PR DESCRIPTION
While trying to use the lib, I wanted to query arbitrary rects, but I had typed the tree to require a specific shape. Therefore I suggest removing the constraint when retrieving objects.