### PR TITLE
Fast retrieve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
 node_modules
 .DS_Store
+
+
+# VsCode workspaces
+*.code-workspace
+
+# Optional eslint cache
+.eslintcache
+
+# TypeScript cache
+*.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -1288,6 +1288,64 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
@@ -1836,9 +1894,9 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5478,9 +5536,9 @@
       }
     },
     "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
       "dev": true
     },
     "node_modules/kleur": {
@@ -5617,12 +5675,12 @@
       }
     },
     "node_modules/marked": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-      "integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
+      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
       "dev": true,
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 12"
@@ -5699,9 +5757,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -5787,30 +5845,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^5.1.1"
-      }
-    },
-    "node_modules/onigasm/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/onigasm/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/optionator": {
       "version": "0.9.1",
@@ -6328,13 +6362,13 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.12.tgz",
-      "integrity": "sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
       "dependencies": {
         "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
+        "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
     },
@@ -6419,9 +6453,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -6647,20 +6681,33 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/test-exclude": {
@@ -6690,9 +6737,9 @@
       "dev": true
     },
     "node_modules/tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "node_modules/to-fast-properties": {
@@ -6852,16 +6899,16 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-      "integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "dependencies": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^3.0.4",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.9.11"
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -6870,7 +6917,47 @@
         "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/typescript": {
@@ -6923,6 +7010,12 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
     },
     "node_modules/vscode-textmate": {
       "version": "5.2.0",
@@ -8124,6 +8217,55 @@
         }
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "@microsoft/tsdoc": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
@@ -8533,9 +8675,9 @@
       }
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -11301,9 +11443,9 @@
       }
     },
     "jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.1.0.tgz",
+      "integrity": "sha512-DRf0QjnNeCUds3xTjKlQQ3DpJD51GvDjJfnxUVWg6PZTo2otSm+slzNAxU/35hF8/oJIKoG9slq30JYOsF2azg==",
       "dev": true
     },
     "kleur": {
@@ -11418,9 +11560,9 @@
       }
     },
     "marked": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.7.tgz",
-      "integrity": "sha512-ctKqbnLuNbsHbI26cfMyOlKgXGfl1orOv1AvWWDX7AkgfMOwCWvmuYc+mVLeWhQ9W6hdWVBynOs96VkcscKo0Q==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
+      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw==",
       "dev": true
     },
     "merge-stream": {
@@ -11476,9 +11618,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {
@@ -11548,32 +11690,6 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
-      }
-    },
-    "onigasm": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/onigasm/-/onigasm-2.2.5.tgz",
-      "integrity": "sha512-F+th54mPc0l1lp1ZcFMyL/jTs2Tlq4SqIHKIXGZOR/VkHkF9A7Fr5rRr5+ZG/lWeRsyrClLYRq7s/yFQ/XhWCA==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^5.1.1"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
-        }
       }
     },
     "optionator": {
@@ -11924,13 +12040,13 @@
       "dev": true
     },
     "shiki": {
-      "version": "0.9.12",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.12.tgz",
-      "integrity": "sha512-VXcROdldv0/Qu0w2XvzU4IrvTeBNs/Kj/FCmtcEXGz7Tic/veQzliJj6tEiAgoKianhQstpYmbPDStHU5Opqcw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
-        "onigasm": "^2.2.5",
+        "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
       }
     },
@@ -11996,9 +12112,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -12177,14 +12293,23 @@
       }
     },
     "terser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+          "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+          "dev": true
+        }
       }
     },
     "test-exclude": {
@@ -12211,9 +12336,9 @@
       "dev": true
     },
     "tmpl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
+      "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true
     },
     "to-fast-properties": {
@@ -12321,16 +12446,49 @@
       }
     },
     "typedoc": {
-      "version": "0.22.5",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.5.tgz",
-      "integrity": "sha512-KFrWGU1iKiTGw0RcyjLNYDmhd7uICU14HgBNPmFKY/sT4Pm/fraaLyWyisst9vGTUAKxqibqoDITR7+ZcAkhHg==",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "requires": {
-        "glob": "^7.2.0",
+        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^3.0.4",
-        "minimatch": "^3.0.4",
-        "shiki": "^0.9.11"
+        "marked": "^4.0.16",
+        "minimatch": "^5.1.0",
+        "shiki": "^0.10.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "typescript": {
@@ -12370,6 +12528,12 @@
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       }
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
+      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA==",
+      "dev": true
     },
     "vscode-textmate": {
       "version": "5.2.0",

--- a/src/Circle.ts
+++ b/src/Circle.ts
@@ -196,42 +196,42 @@ export class Circle<CustomDataType = void> implements CircleGeometry, Indexable 
      * @param props - Circle properties
      * @typeParam CustomDataType - Type of the custom data property (optional, inferred automatically).
      */
-    constructor(props:CircleProps<CustomDataType>) {
+    constructor(props: CircleProps<CustomDataType>) {
 
         this.x = props.x;
         this.y = props.y;
         this.r = props.r;
         this.data = props.data;
     }
-    
+
     /**
      * Determine which quadrant this circle belongs to.
      * @param node - Quadtree node to be checked
      * @returns Array containing indexes of intersecting subnodes (0-3 = top-right, top-left, bottom-left, bottom-right)
      */
-    qtIndex(node:NodeGeometry): number[] {
+    qtIndex(node: NodeGeometry): number[] {
 
-        const indexes:number[] = [],
-            w2 = node.width/2,
-            h2 = node.height/2,
+        const indexes: number[] = [],
+            w2 = node.width / 2,
+            h2 = node.height / 2,
             x2 = node.x + w2,
             y2 = node.y + h2;
 
         //an array of node origins where the array index equals the node index
         const nodes = [
-            [x2,     node.y],
+            [x2, node.y],
             [node.x, node.y],
             [node.x, y2],
-            [x2,     y2],
+            [x2, y2],
         ];
 
         //test all nodes for circle intersections
-        for(let i=0; i<nodes.length; i++) {
-            if(Circle.intersectRect(this.x, this.y, this.r, nodes[i][0], nodes[i][1], nodes[i][0] + w2, nodes[i][1] + h2)) {
+        for (let i = 0; i < nodes.length; i++) {
+            if (Circle.intersectRect(this.x, this.y, this.r, nodes[i][0], nodes[i][1], nodes[i][0] + w2, nodes[i][1] + h2)) {
                 indexes.push(i);
             }
         }
-     
+
         return indexes;
     }
 
@@ -264,7 +264,7 @@ export class Circle<CustomDataType = void> implements CircleGeometry, Indexable 
      * console.log(circle, rect, 'intersect?', intersect);
      * ```
      */
-    static intersectRect(x:number, y:number, r:number, minX:number, minY:number, maxX:number, maxY:number): boolean {
+    static intersectRect(x: number, y: number, r: number, minX: number, minY: number, maxX: number, maxY: number): boolean {
         const deltaX = x - Math.max(minX, Math.min(x, maxX));
         const deltaY = y - Math.max(minY, Math.min(y, maxY));
         return (deltaX * deltaX + deltaY * deltaY) < (r * r);

--- a/src/Line.ts
+++ b/src/Line.ts
@@ -214,7 +214,7 @@ export class Line<CustomDataType = void> implements LineGeometry, Indexable {
      * @param props - Line properties
      * @typeParam CustomDataType - Type of the custom data property (optional, inferred automatically).
      */
-    constructor(props:LineProps<CustomDataType>) {
+    constructor(props: LineProps<CustomDataType>) {
 
         this.x1 = props.x1;
         this.y1 = props.y1;
@@ -222,37 +222,37 @@ export class Line<CustomDataType = void> implements LineGeometry, Indexable {
         this.y2 = props.y2;
         this.data = props.data;
     }
-    
+
     /**
      * Determine which quadrant this line belongs to.
      * @beta
      * @param node - Quadtree node to be checked
      * @returns Array containing indexes of intersecting subnodes (0-3 = top-right, top-left, bottom-left, bottom-right)
      */
-    qtIndex(node:NodeGeometry): number[] {
+    qtIndex(node: NodeGeometry): number[] {
 
-        const indexes:number[] = [],
-            w2 = node.width/2,
-            h2 = node.height/2,
+        const indexes: number[] = [],
+            w2 = node.width / 2,
+            h2 = node.height / 2,
             x2 = node.x + w2,
             y2 = node.y + h2;
 
         //an array of node origins where the array index equals the node index
         const nodes = [
-            [x2,     node.y],
+            [x2, node.y],
             [node.x, node.y],
             [node.x, y2],
-            [x2,     y2],
+            [x2, y2],
         ];
 
         //test all nodes for line intersections
-        for(let i=0; i<nodes.length; i++) {
-            if(Line.intersectRect(this.x1, this.y1, this.x2, this.y2, 
+        for (let i = 0; i < nodes.length; i++) {
+            if (Line.intersectRect(this.x1, this.y1, this.x2, this.y2,
                 nodes[i][0], nodes[i][1], nodes[i][0] + w2, nodes[i][1] + h2)) {
                 indexes.push(i);
             }
         }
-     
+
         return indexes;
     }
 
@@ -275,8 +275,8 @@ export class Line<CustomDataType = void> implements LineGeometry, Indexable {
      * @param maxY - rectangle end Y
      * @returns true if the line segment intersects the axis aligned rectangle
      */
-    static intersectRect(x1:number, y1:number, x2:number, y2:number, minX:number, minY:number, maxX:number, maxY:number): boolean {
-    
+    static intersectRect(x1: number, y1: number, x2: number, y2: number, minX: number, minY: number, maxX: number, maxY: number): boolean {
+
         // Completely outside
         if ((x1 <= minX && x2 <= minX) || (y1 <= minY && y2 <= minY) || (x1 >= maxX && x2 >= maxX) || (y1 >= maxY && y2 >= maxY))
             return false;
@@ -284,21 +284,21 @@ export class Line<CustomDataType = void> implements LineGeometry, Indexable {
         // Single point inside
         if ((x1 >= minX && x1 <= maxX && y1 >= minY && y1 <= maxY) || (x2 >= minX && x2 <= maxX && y2 >= minY && y2 <= maxY))
             return true;
-    
+
         const m = (y2 - y1) / (x2 - x1);
-    
+
         let y = m * (minX - x1) + y1;
         if (y > minY && y < maxY) return true;
-    
+
         y = m * (maxX - x1) + y1;
         if (y > minY && y < maxY) return true;
-    
+
         let x = (minY - y1) / m + x1;
         if (x > minX && x < maxX) return true;
-    
+
         x = (maxY - y1) / m + x1;
         if (x > minX && x < maxX) return true;
-    
+
         return false;
     }
 }

--- a/src/Quadtree.ts
+++ b/src/Quadtree.ts
@@ -69,7 +69,7 @@ export interface QuadtreeProps {
  * });
  * ```
  */
-export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
+export class Quadtree<ObjectsType extends Rectangle | Circle | Line | Indexable> {
 
     /**
      * The numeric boundaries of this node.
@@ -83,7 +83,7 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @readonly
      */
     maxObjects: number;
-    
+
     /**
      * Total max nesting levels of the root Quadtree node.
      * @defaultValue `4`
@@ -117,22 +117,22 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @param props - bounds and properties of the node
      * @param level - depth level (internal use only, required for subnodes)
      */
-    constructor(props:QuadtreeProps, level=0) {
-        
-        this.bounds = { 
-            x: props.x || 0, 
-            y: props.y || 0, 
-            width: props.width, 
+    constructor(props: QuadtreeProps, level = 0) {
+
+        this.bounds = {
+            x: props.x || 0,
+            y: props.y || 0,
+            width: props.width,
             height: props.height,
         };
         this.maxObjects = (typeof props.maxObjects === 'number') ? props.maxObjects : 10;
-        this.maxLevels  = (typeof props.maxLevels === 'number') ? props.maxLevels : 4;
-        this.level      = level;
-        
+        this.maxLevels = (typeof props.maxLevels === 'number') ? props.maxLevels : 4;
+        this.level = level;
+
         this.objects = [];
-        this.nodes   = [];
+        this.nodes = [];
     }
-    
+
     /**
      * Get the quadrant (subnode indexes) an object belongs to.
      * 
@@ -147,7 +147,7 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @param obj - object to be checked
      * @returns Array containing indexes of intersecting subnodes (0-3 = top-right, top-left, bottom-left, bottom-right).
      */
-    getIndex(obj:Rectangle|Circle|Line|Indexable): number[] {
+    getIndex(obj: Rectangle | Circle | Line | Indexable): number[] {
         return obj.qtIndex(this.bounds);
     }
 
@@ -163,30 +163,30 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * ```
      */
     split(): void {
-        
+
         const level = this.level + 1,
-            width   = this.bounds.width/2,
-            height  = this.bounds.height/2,
-            x       = this.bounds.x,
-            y       = this.bounds.y;
+            width = this.bounds.width / 2,
+            height = this.bounds.height / 2,
+            x = this.bounds.x,
+            y = this.bounds.y;
 
         const coords = [
             { x: x + width, y: y },
-            { x: x,         y: y },
-            { x: x,         y: y + height },
+            { x: x, y: y },
+            { x: x, y: y + height },
             { x: x + width, y: y + height },
         ];
 
-        for(let i=0; i < 4; i++) {
+        for (let i = 0; i < 4; i++) {
             this.nodes[i] = new Quadtree({
-                x: coords[i].x, 
-                y: coords[i].y, 
+                x: coords[i].x,
+                y: coords[i].y,
                 width,
                 height,
                 maxObjects: this.maxObjects,
                 maxLevels: this.maxLevels,
             }, level);
-        }        
+        }
     }
 
 
@@ -205,33 +205,33 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * 
      * @param obj - Object to be added.
      */
-    insert(obj:ObjectsType): void {
-        
+    insert(obj: ObjectsType): void {
+
         //if we have subnodes, call insert on matching subnodes
-        if(this.nodes.length) {
+        if (this.nodes.length) {
             const indexes = this.getIndex(obj);
-    
-            for(let i=0; i<indexes.length; i++) {
+
+            for (let i = 0; i < indexes.length; i++) {
                 this.nodes[indexes[i]].insert(obj);
             }
             return;
         }
-    
+
         //otherwise, store object here
         this.objects.push(obj);
 
         //maxObjects reached
-        if(this.objects.length > this.maxObjects && this.level < this.maxLevels) {
+        if (this.objects.length > this.maxObjects && this.level < this.maxLevels) {
 
             //split if we don't already have subnodes
-            if(!this.nodes.length) {
+            if (!this.nodes.length) {
                 this.split();
             }
-            
+
             //add all objects to their corresponding subnode
-            for(let i=0; i<this.objects.length; i++) {
+            for (let i = 0; i < this.objects.length; i++) {
                 const indexes = this.getIndex(this.objects[i]);
-                for(let k=0; k<indexes.length; k++) {
+                for (let k = 0; k < indexes.length; k++) {
                     this.nodes[indexes[k]].insert(this.objects[i]);
                 }
             }
@@ -240,8 +240,8 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
             this.objects = [];
         }
     }
-    
-    
+
+
     /**
      * Return all objects that could collide with the given geometry.
      * 
@@ -255,23 +255,23 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @param obj - geometry to be checked
      * @returns Array containing all detected objects.
      */
-    retrieve(obj:Rectangle|Circle|Line|Indexable): ObjectsType[] {
-        
+    retrieve(obj: Rectangle | Circle | Line | Indexable): ObjectsType[] {
+
         const indexes = this.getIndex(obj);
         let returnObjects = this.objects;
-            
+
         //if we have subnodes, retrieve their objects
-        if(this.nodes.length) {
-            for(let i=0; i<indexes.length; i++) {
+        if (this.nodes.length) {
+            for (let i = 0; i < indexes.length; i++) {
                 returnObjects = returnObjects.concat(this.nodes[indexes[i]].retrieve(obj));
             }
         }
 
         //remove duplicates
-        returnObjects = returnObjects.filter(function(item, index) {
+        returnObjects = returnObjects.filter(function (item, index) {
             return returnObjects.indexOf(item) >= index;
         });
-    
+
         return returnObjects;
     }
 
@@ -288,11 +288,11 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * ```
      */
     clear(): void {
-        
+
         this.objects = [];
-    
-        for(let i=0; i < this.nodes.length; i++) {
-            if(this.nodes.length) {
+
+        for (let i = 0; i < this.nodes.length; i++) {
+            if (this.nodes.length) {
                 this.nodes[i].clear();
             }
         }

--- a/src/Quadtree.ts
+++ b/src/Quadtree.ts
@@ -255,24 +255,29 @@ export class Quadtree<ObjectsType extends Rectangle | Circle | Line | Indexable>
      * @param obj - geometry to be checked
      * @returns Array containing all detected objects.
      */
-    retrieve(obj: Rectangle | Circle | Line | Indexable): ObjectsType[] {
+    retrieve(obj: Rectangle | Circle | Line | Indexable, results: ObjectsType[] = []): ObjectsType[] {
 
-        const indexes = this.getIndex(obj);
-        let returnObjects = this.objects;
+        const objects = this.objects;
+        if (objects.length) {
 
-        //if we have subnodes, retrieve their objects
-        if (this.nodes.length) {
-            for (let i = 0; i < indexes.length; i++) {
-                returnObjects = returnObjects.concat(this.nodes[indexes[i]].retrieve(obj));
+            for (let i = objects.length - 1; i >= 0; i--) {
+                if (results.indexOf(objects[i]) < 0) {
+                    results.push(objects[i]);
+                }
             }
+
+        } else if (this.nodes.length) {
+
+            //if we have subnodes, retrieve their objects
+            const indexes = this.getIndex(obj);
+
+            for (let i = 0; i < indexes.length; i++) {
+                this.nodes[indexes[i]].retrieve(obj, results);
+            }
+
         }
 
-        //remove duplicates
-        returnObjects = returnObjects.filter(function (item, index) {
-            return returnObjects.indexOf(item) >= index;
-        });
-
-        return returnObjects;
+        return results;
     }
 
 

--- a/src/Rectangle.ts
+++ b/src/Rectangle.ts
@@ -209,51 +209,51 @@ export class Rectangle<CustomDataType = void> implements RectangleGeometry, Inde
      */
     data?: CustomDataType;
 
-    constructor(props:RectangleProps<CustomDataType>) {
-        
+    constructor(props: RectangleProps<CustomDataType>) {
+
         this.x = props.x;
         this.y = props.y;
         this.width = props.width;
         this.height = props.height;
         this.data = props.data;
     }
-    
+
     /**
      * Determine which quadrant this rectangle belongs to.
      * @param node - Quadtree node to be checked
      * @returns Array containing indexes of intersecting subnodes (0-3 = top-right, top-left, bottom-left, bottom-right)
      */
-    qtIndex(node:NodeGeometry): number[] {
-        
-        const indexes:number[] = [],
-            boundsCenterX   = node.x + (node.width/2),
-            boundsCenterY   = node.y + (node.height/2);
+    qtIndex(node: NodeGeometry): number[] {
 
-        const startIsNorth  = this.y < boundsCenterY,
-            startIsWest     = this.x < boundsCenterX,
-            endIsEast       = this.x + this.width > boundsCenterX,
-            endIsSouth      = this.y + this.height > boundsCenterY;
+        const indexes: number[] = [],
+            boundsCenterX = node.x + (node.width / 2),
+            boundsCenterY = node.y + (node.height / 2);
+
+        const startIsNorth = this.y < boundsCenterY,
+            startIsWest = this.x < boundsCenterX,
+            endIsEast = this.x + this.width > boundsCenterX,
+            endIsSouth = this.y + this.height > boundsCenterY;
 
         //top-right quad
-        if(startIsNorth && endIsEast) {
+        if (startIsNorth && endIsEast) {
             indexes.push(0);
         }
-        
+
         //top-left quad
-        if(startIsWest && startIsNorth) {
+        if (startIsWest && startIsNorth) {
             indexes.push(1);
         }
 
         //bottom-left quad
-        if(startIsWest && endIsSouth) {
+        if (startIsWest && endIsSouth) {
             indexes.push(2);
         }
 
         //bottom-right quad
-        if(endIsEast && endIsSouth) {
+        if (endIsEast && endIsSouth) {
             indexes.push(3);
         }
-     
+
         return indexes;
     }
 }


### PR DESCRIPTION
1) Updated quadtree.retrieve() to allow passing `results` array to retrieve to avoid creating arrays during retrieval.
( This option to allow reusing a results array is used in Unity physics hit test functions so I don't consider it too unreasonable.)

2) getIndex() not called if objects.length >0 since objects are only stored in leaf nodes.

All npm tests passed.

I don't consider this premature optimization because geometric queries are often performance critical by nature. (Graphics and game libraries, thousands of hit tests per frame, etc. ) I didn't test these changes were actually faster but it should be.

Don't know about the whitespace. VSCode likes to autoformat.