### PR TITLE
updated code and types to allow Quadtree class to be extended

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/parser": "^4.29.3",
         "eslint": "^7.32.0",
         "eslint-plugin-tsdoc": "^0.2.14",
+        "expect-type": "^1.2.2",
         "jest": "^27.1.0",
         "rollup": "^2.56.2",
         "rollup-plugin-banner2": "^1.2.2",
@@ -2991,6 +2992,16 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expect/node_modules/ansi-styles": {
@@ -9545,6 +9556,12 @@
           "dev": true
         }
       }
+    },
+    "expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@typescript-eslint/parser": "^4.29.3",
     "eslint": "^7.32.0",
     "eslint-plugin-tsdoc": "^0.2.14",
+    "expect-type": "^1.2.2",
     "jest": "^27.1.0",
     "rollup": "^2.56.2",
     "rollup-plugin-banner2": "^1.2.2",

--- a/src/Quadtree.ts
+++ b/src/Quadtree.ts
@@ -110,7 +110,7 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
      * @defaultValue `[]`
      * @readonly
      */
-    nodes: Quadtree<ObjectsType>[];
+    nodes: this[];
 
     /**
      * Quadtree Constructor
@@ -177,10 +177,12 @@ export class Quadtree<ObjectsType extends Rectangle|Circle|Line|Indexable> {
             { x: x + width, y: y + height },
         ];
 
+        const Constructor = this.constructor as new (props: QuadtreeProps, level: number) => this;
+
         for(let i=0; i < 4; i++) {
-            this.nodes[i] = new Quadtree({
-                x: coords[i].x, 
-                y: coords[i].y, 
+            this.nodes[i] =  new Constructor({
+                x: coords[i].x,
+                y: coords[i].y,
                 width,
                 height,
                 maxObjects: this.maxObjects,

--- a/test/Quadtree/Quadtree.test.ts
+++ b/test/Quadtree/Quadtree.test.ts
@@ -1,4 +1,10 @@
-import { Quadtree } from '../../src/Quadtree';
+import { Quadtree, QuadtreeProps } from '../../src/Quadtree';
+import type { Rectangle } from '../../src/Rectangle';
+import type { Circle } from '../../src/Circle';
+import type { Line } from '../../src/Line';
+import type { Indexable } from '../../src/types';
+import { expectTypeOf } from 'expect-type';
+type ObjectsTypeDefault = Rectangle|Circle|Line|Indexable
 
 describe('Quadtree.constructor', () => {
 
@@ -12,6 +18,8 @@ describe('Quadtree.constructor', () => {
         expect(tree.level).toBe(0);
         expect(tree.objects).toEqual([]);
         expect(tree.nodes).toEqual([]);
+
+        expectTypeOf(tree.nodes).toEqualTypeOf<Quadtree<ObjectsTypeDefault>[]>();
     });
 
     test('applies all arguments', () => {
@@ -21,6 +29,27 @@ describe('Quadtree.constructor', () => {
         expect(tree.bounds).toEqual({ x: 20, y: 40, width: 100, height: 200 });
         expect(tree.maxObjects).toBe(5);
         expect(tree.maxLevels).toBe(3);
+    });
+
+    test('handles subclass extension', () => {
+        class SubQuadTree<ObjectsType extends ObjectsTypeDefault> extends Quadtree<ObjectsType> {
+            public isSubClass: boolean
+
+            constructor(props:QuadtreeProps, level=0) {
+                super(props, level);
+                this.isSubClass = true;
+            }
+        }
+
+        const tree = new SubQuadTree({ x: 20, y: 40, width: 100, height: 200, maxObjects: 5, maxLevels: 3 });
+        tree.split();
+        expectTypeOf(tree.nodes).toEqualTypeOf<SubQuadTree<ObjectsTypeDefault>[]>();
+
+        for(const node of tree.nodes){
+            expect(node).toBeInstanceOf(SubQuadTree);
+            expect(node.isSubClass).toBe(true);
+            expectTypeOf(node).toEqualTypeOf<SubQuadTree<ObjectsTypeDefault>>();
+        }
     });
 });
 


### PR DESCRIPTION
These changes make it possible to subclass the QuadTree class.
I needed a way to monitor the creation and destruction of QuadTree instances.